### PR TITLE
Allow keywords as identifier in graphical query

### DIFF
--- a/src/app/views/querying/graphical-querying/graphical-querying.component.ts
+++ b/src/app/views/querying/graphical-querying/graphical-querying.component.ts
@@ -106,13 +106,14 @@ export class GraphicalQueryingComponent implements OnInit, AfterViewInit, OnDest
     let sql = 'SELECT ';
     const cols = [];
     $('#selectBox').find('.dbCol').each( (i, el) => {
-      cols.push( $(el).attr('data-id') );
+      const id = "\""+$(el).attr('data-id').split(".").join("\".\"")+"\""
+      cols.push( id );
     });
     sql += cols.join(', ');
     sql += '\nFROM ';
     const tables = [];
     this.tables.forEach( (v, k) => {
-      tables.push( k );
+      tables.push( "\"" + k.split(".").join("\".\"") + "\"" );
     });
     sql += tables.join(', ');
 


### PR DESCRIPTION
Allows keywords as identifier by wraping them in parentheses in the Graphical Query section.
![image](https://user-images.githubusercontent.com/5930207/73455172-d27c1700-436f-11ea-9688-aad4f7f876db.png)
