### PR TITLE
Refactoring of the toast service

### DIFF
--- a/src/app/components/data-table/data-table.component.ts
+++ b/src/app/components/data-table/data-table.component.ts
@@ -5,7 +5,7 @@ import {DeleteRequest, TableRequest, UpdateRequest} from '../../models/ui-reques
 import {PaginationElement} from './models/pagination-element.model';
 import {ResultSet} from './models/result-set.model';
 import {SortDirection, SortState} from './models/sort-state.model';
-import {ToastService} from '../toast/toast.service';
+import {ToastDuration, ToastService} from '../toast/toast.service';
 import {CrudService} from '../../services/crud.service';
 import {ActivatedRoute, Router} from '@angular/router';
 import {DbmsTypesService} from '../../services/dbms-types.service';
@@ -194,13 +194,12 @@ export class DataTableComponent implements OnInit, OnChanges {
             this.insertValues.clear();
             this.buildInsertObject();
             this.getTable();
-            this._toast.toast( 'success', 'Saved data', 1, 'bg-success' );
           } else if ( result.error ) {
-            this._toast.toast( 'insert error', 'Could not insert the data: ' + result.error, 10, 'bg-warning' );
+            this._toast.warn('Could not insert the data: ' + result.error, 'insert error');
           }
         }, err => {
-          this._toast.toast( 'server error', 'Could not insert the data.', 10, 'bg-danger' );
-          console.log(err);
+        this._toast.error('Could not insert the data.');
+        console.log(err);
         }
     );
   }
@@ -226,12 +225,12 @@ export class DataTableComponent implements OnInit, OnChanges {
           this.getTable();
           let rows = ' rows';
           if(result.info.affectedRows === 1) rows = ' row';
-          this._toast.toast( 'update', 'Updated ' + result.info.affectedRows + rows, 1, 'bg-success' );
+          this._toast.success('Updated ' + result.info.affectedRows + rows, 'update', ToastDuration.SHORT);
         } else if ( result.error ){
-          this._toast.toast( 'error', 'Could not update this row: '+result.error, 10, 'bg-warning' );
+          this._toast.warn('Could not update this row: ' + result.error);
         }
       }, err => {
-        this._toast.toast( 'server error', 'Could not update the data.', 10, 'bg-danger' );
+        this._toast.error('Could not update the data.');
         console.log(err);
       }
     );
@@ -266,8 +265,8 @@ export class DataTableComponent implements OnInit, OnChanges {
             this.config.delete = false;
           }
         }, err => {
-        this._toast.toast( 'server error', 'Could not load the data.', 10, 'bg-danger' );
-          console.log(err);
+        this._toast.error('Could not load the data.');
+        console.log(err);
         }
     );
   }
@@ -329,11 +328,11 @@ export class DataTableComponent implements OnInit, OnChanges {
             this.getTable();
           }else {
             const result2 = <ResultSet> res;
-            this._toast.toast( 'error', 'Could not delete this row: ' + result2.error, 10, 'bg-warning' );
+            this._toast.warn('Could not delete this row: ' + result2.error);
           }
         }, err => {
-        this._toast.toast( 'server error', 'Could not delete this row.', 10, 'bg-danger' );
-          console.log(err);
+        this._toast.error('Could not delete this row.');
+        console.log(err);
         }
     );
   }

--- a/src/app/components/toast/toast.service.ts
+++ b/src/app/components/toast/toast.service.ts
@@ -14,28 +14,81 @@ export class ToastService {
 
   /**
    * Generate a toast message
-   * @param title title of the message
-   * @param message message
+   * @param title Title of the message
+   * @param message Message
    * @param delay After how many seconds the message should fade out. The message will be displayed permanently if delay = 0
    * @param type Set the type of the message, e.g. 'bg-success', 'bg-warning', 'bg-danger'
    */
-  toast(title:string, message:string, delay:number, type:String=''){
-    const t:Toast = new Toast( title, message, delay, type );
+  private toast(title: string, message: string, delay: number, type: String = '') {
+    const t: Toast = new Toast(title, message, delay, type);
     //const d:Date = new Date();
     //this.toasts.set(d, t);
-    this.toasts.set ( t.hash, t);
+    this.toasts.set(t.hash, t);
     //this.toastEvent.next(this.toasts);
-    if(t.delay > 0){
-      setTimeout( () => {
-        this.toasts.delete( t.hash );
+    if (t.delay > 0) {
+      setTimeout(() => {
+        this.toasts.delete(t.hash);
         //this.toastEvent.next(this.toasts);
-      }, t.delay*1000 );
+      }, t.delay * 1000);
     }
   }
 
-  deleteToast ( key ) {
-    this.toasts.delete( key );
+  /**
+   * Generate a success toast message
+   * @param message Message
+   * @param title Title of the message, default: 'success'. If null, it will be set to 'success'
+   * @param duration Optional. Set the duration of the toast message. Default: NORMAL
+   */
+  success(message: string, title = 'success', duration: ToastDuration = ToastDuration.NORMAL) {
+    if (!title) {
+      title = 'success';
+    }
+    this.toast(title, message, duration.valueOf(), 'bg-success');
+  }
+
+  /**
+   * Generate a warning toast message. Use this method for errors caught by the UI.
+   * @param message Message
+   * @param title Title of the message, default: 'warning'. If null, it will be set to 'warning'
+   * @param duration Optional. Set the duration of the toast message. Default LONG
+   */
+  warn(message: string, title = 'warning', duration: ToastDuration = ToastDuration.LONG) {
+    if (!title) {
+      title = 'warning';
+    }
+    this.toast(title, message, duration.valueOf(), 'bg-warning');
+  }
+
+  /**
+   * Generate a error toast message. Use this method for errors from the backend.
+   * @param message Message
+   * @param title Title of the message, default: 'error'. If null, it will be set to 'error'
+   * @param duration Optional. Set the duration of the toast message. Default LONG
+   */
+  error(message: string, title = 'error', duration: ToastDuration = ToastDuration.LONG) {
+    if (!title) {
+      title = 'error';
+    }
+    this.toast(title, message, duration.valueOf(), 'bg-danger');
+  }
+
+  deleteToast(key) {
+    this.toasts.delete(key);
     //this.toastEvent.next( this.toasts );
   }
 
+}
+
+/**
+ * Duration of a toast message
+ * INFINITE: will only close when the user clicks on it
+ * SHORT: for a very short notice
+ * NORMAL: the default for success messages
+ * LONG: a longer message, default for warning and error messages
+ */
+export enum ToastDuration {
+  INFINITE = 0,
+  SHORT = 2,
+  NORMAL = 5,
+  LONG = 10
 }

--- a/src/app/services/dbms-types.service.ts
+++ b/src/app/services/dbms-types.service.ts
@@ -29,7 +29,7 @@ export class DbmsTypesService {
       res=> {
         const result = <ResultSet> res;
         if( result.error ){
-          this._toast.toast( 'server error', 'Could not retrieve DBMS types.', 10, 'bg-danger' );
+          this._toast.error('Could not retrieve DBMS types.');
           return;
         }
         const types = [];
@@ -39,7 +39,7 @@ export class DbmsTypesService {
         types.sort();
         this.types.next( types );
       }, err => {
-        this._toast.toast( 'server error', 'Could not retrieve DBMS types.', 10, 'bg-danger' );
+        this._toast.error('Could not retrieve DBMS types.');
       }
     );
 
@@ -53,7 +53,7 @@ export class DbmsTypesService {
       res => {
         this.foreignKeyActions.next( res );
       }, err => {
-        this._toast.toast( 'server error', 'Could not retrieve DBMS foreign key actions.', 10, 'bg-danger' );
+        this._toast.error('Could not retrieve DBMS foreign key actions.');
     }
     );
   }

--- a/src/app/views/forms/form-generator/form-generator.component.ts
+++ b/src/app/views/forms/form-generator/form-generator.component.ts
@@ -1,12 +1,12 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
-import { ConfigService } from '../../../services/config.service';
-import { FormControl, FormGroup, Validators } from '@angular/forms';
-import { ActivatedRoute } from '@angular/router';
-import { LeftSidebarService } from '../../../components/left-sidebar/left-sidebar.service';
+import {Component, OnDestroy, OnInit} from '@angular/core';
+import {ConfigService} from '../../../services/config.service';
+import {FormControl, FormGroup, Validators} from '@angular/forms';
+import {ActivatedRoute} from '@angular/router';
+import {LeftSidebarService} from '../../../components/left-sidebar/left-sidebar.service';
 import {KeyValue} from '@angular/common';
 import {BreadcrumbService} from '../../../components/breadcrumb/breadcrumb.service';
 import {BreadcrumbItem} from '../../../components/breadcrumb/breadcrumb-item';
-import {ToastService} from '../../../components/toast/toast.service';
+import {ToastDuration, ToastService} from '../../../components/toast/toast.service';
 
 @Component({
   selector: 'app-form-generator',
@@ -71,9 +71,9 @@ export class FormGeneratorComponent implements OnInit, OnDestroy {
           c.value = update.value;
         }else {//has been edited
           if(this.form.controls[c.key].value !== update.value){
-            this._toast.toast( 'incoming change',
-              'The setting with id ' + c.key + ' has been changed to the new value "'+ update.value +'" by the server. If you save, these changes will be overwritten.',
-              0, 'bg-warning');
+            this._toast.warn(
+              'The setting with id ' + c.key + ' has been changed to the new value "' + update.value + '" by the server. If you save, these changes will be overwritten.',
+              'incoming change', ToastDuration.INFINITE);
           }else{
             c.value = update.value;
           }
@@ -216,17 +216,17 @@ export class FormGeneratorComponent implements OnInit, OnDestroy {
         const f: Feedback = <Feedback> res;
         //console.log(f);
         if( f.success ){
-          this._toast.toast('success', 'Saved changes.', 2, 'bg-success');
+          this._toast.success('Saved changes.', null, ToastDuration.SHORT);
         } else {
-          this._toast.toast('warning', f.warning, 0, 'bg-warning');
+          this._toast.warn(f.warning, null, ToastDuration.INFINITE);
         }
         this.form.markAsPristine();
       }, err=>{
         console.log(err);
-        this._toast.toast('server error', 'an error occurred on the server', 3,  'bg-danger');
+        this._toast.error('an error occurred on the server');
       });
     } else {
-      this._toast.toast('invalid input', 'Changes could not be saved. Please check invalid input.', 0, 'bg-warning');
+      this._toast.warn('Changes could not be saved. Please check invalid input.', 'invalid input', ToastDuration.INFINITE);
     }
   }
 

--- a/src/app/views/hub/hub.component.ts
+++ b/src/app/views/hub/hub.component.ts
@@ -184,14 +184,14 @@ export class HubComponent implements OnInit, OnDestroy {
         res => {
           const result = <HubResult> res;
           if(result.error){
-            this._toast.toast( 'error', result.error, 5, 'bg-warning');
+            this._toast.warn(result.error);
           }else{
-            this._toast.toast( 'Password changed', result.message, 5, 'bg-success');
+            this._toast.success(result.message, 'Password changed');
             this.changePwSubmitted = false;
             this.changePwForm.reset();
           }
         }, err => {
-          this._toast.toast( 'error', 'Unknown server error', 5, 'bg-danger');
+          this._toast.error('Unknown server error');
         }
       );
     }
@@ -206,13 +206,13 @@ export class HubComponent implements OnInit, OnDestroy {
       res => {
         const result = <HubResult> res;
         if( result.error ){
-          this._toast.toast('error', 'Could not delete user: ' + result.error, 10, 'bg-warning');
+          this._toast.warn('Could not delete user: ' + result.error);
         }else{
-          this._toast.toast('success', 'The user was deleted.', 5, 'bg-success');
+          this._toast.success('The user was deleted.');
           this.getUsers();
         }
       }, err => {
-        this._toast.toast('server error', 'Could not delete user', 10, 'bg-danger');
+        this._toast.error('Could not delete user');
       }
     );
   }
@@ -224,16 +224,16 @@ export class HubComponent implements OnInit, OnDestroy {
         res => {
           const result = <HubResult> res;
           if( result.error ){
-            this._toast.toast('error', 'Could not create user: ' + result.error, 10, 'bg-warning');
+            this._toast.warn('Could not create user: ' + result.error);
           }else{
-            this._toast.toast('success', result.message, 5, 'bg-success');
+            this._toast.success(result.message);
             this.getUsers();
             this.newUserForm.reset({admin:false});
             this.newUserFormSubmitted = false;
             this.createUserModal.hide();
           }
         }, err => {
-          this._toast.toast('server error', 'Could not create user', 10, 'bg-danger');
+          this._toast.error('Could not create user');
           console.log(err);
         }
       );
@@ -278,14 +278,14 @@ export class HubComponent implements OnInit, OnDestroy {
         res => {
           const result = <HubResult> res;
           if( result.error ){
-            this._toast.toast('error', 'Could not update user: ' + result.error, 10, 'bg-warning');
+            this._toast.error('Could not update user: ' + result.error);
           }else{
-            this._toast.toast('success', 'The user was updated.', 5, 'bg-success');
+            this._toast.success('The user was updated.');
             this.getUsers();
             this.editUserModal.hide();
           }
         }, err => {
-          this._toast.toast('server error', 'Could not update user', 10, 'bg-danger');
+          this._toast.error('Could not update user');
           console.log(err);
         }
       );
@@ -369,7 +369,7 @@ export class HubComponent implements OnInit, OnDestroy {
         this.editDatasetModal.hide();
         this.getDatasets();
       }, err => {
-        this._toast.toast('error', 'Could not update dataset', 5, 'bg-danger');
+        this._toast.error('Could not update dataset');
         console.log(err);
       }
     );
@@ -388,10 +388,10 @@ export class HubComponent implements OnInit, OnDestroy {
           } else if( res.type === HttpEventType.Response ){
             const result = <HubResult> res.body;
             if( result.error ){
-              this._toast.toast( 'error', 'Could not upload dataset: ' + result.error, 10, 'bg-warning' );
+              this._toast.warn('Could not upload dataset: ' + result.error);
               this.uploadProgress = 0;
             } else {
-              this._toast.toast( 'uploaded', result.message, 5, 'bg-success' );
+              this._toast.success(result.message, 'uploaded');
               this.getDatasets();
               this.newDsForm.reset();
               this.newDsFormSubmitted = false;
@@ -400,7 +400,7 @@ export class HubComponent implements OnInit, OnDestroy {
             }
           }
         }, err => {
-          this._toast.toast( 'error', 'Could not upload dataset', 10, 'bg-danger' );
+          this._toast.error('Could not upload dataset');
           console.log(err);
         }
       );
@@ -423,14 +423,14 @@ export class HubComponent implements OnInit, OnDestroy {
         const result = <HubResult> res;
         this.deleteDsConfirm = undefined;
         if( result.error ){
-          this._toast.toast( 'error', 'Could not delete dataset: ' + result.error, 10, 'bg-warning' );
+          this._toast.warn('Could not delete dataset: ' + result.error);
         } else {
-          // this._toast.toast( 'deleted', result.message, 5, 'bg-success' );
+          // this._toast.success( result.message, 'deleted' );
           this.getDatasets();
         }
       }, err => {
         this.deleteDsConfirm = undefined;
-        this._toast.toast( 'error', 'Could not delete dataset', 10, 'bg-danger' );
+        this._toast.error('Could not delete dataset');
       }
     );
   }
@@ -491,14 +491,14 @@ export class HubComponent implements OnInit, OnDestroy {
           this.importProgress = -1;
           const result = <HubResult> res;
           if(result.error){
-            this._toast.toast('error', 'Import failed: ' + result.error, 10, 'bg-warning');
+            this._toast.warn('Import failed: ' + result.error);
           }else{
-            this._toast.toast('success', result.message, 5, 'bg-success');
+            this._toast.success(result.message);
             this.downloadDataModal.hide();
           }
         }, err => {
           this.importProgress = -1;
-          this._toast.toast('error', 'The dataset could not be imported', 10, 'bg-warning');
+          this._toast.error('The dataset could not be imported');
           console.log(err);
         }
       );

--- a/src/app/views/querying/graphical-querying/graphical-querying.component.ts
+++ b/src/app/views/querying/graphical-querying/graphical-querying.component.ts
@@ -363,8 +363,8 @@ export class GraphicalQueryingComponent implements OnInit, AfterViewInit, OnDest
                     this.resultSet = result[0];
                     this.loading = false;
                 }, err => {
-                    this._toast.toast('server error', 'Unknown error on the server.', 10, 'bg-danger');
-                    this.loading = false;
+                    this._toast.error('Unknown error on the server.');
+            this.loading = false;
                 }
         );
     }
@@ -394,7 +394,7 @@ export class GraphicalQueryingComponent implements OnInit, AfterViewInit, OnDest
                         this.umlData.set(treeElement.getSchema(), uml);
                         this.generateJoinConditions();
                     }, err => {
-                        this._toast.toast('server error', 'Could not get foreign keys of the schema ' + treeElement.getSchema(), 10, 'bg-danger');
+                this._toast.error('Could not get foreign keys of the schema ' + treeElement.getSchema());
                     }
             );
         } else {

--- a/src/app/views/querying/graphical-querying/refinement-options/refinement-options.component.ts
+++ b/src/app/views/querying/graphical-querying/refinement-options/refinement-options.component.ts
@@ -69,7 +69,7 @@ export class RefinementOptionsComponent implements OnInit {
                     this.prepareStatisticSet(<StatisticSet>res);
                     this.stylingSet = res;
                 }, err => {
-                    this._toast.toast('server error', 'Unknown error on the server.', 10, 'bg-danger');
+                    this._toast.error('Unknown error on the server.');
                 }
         );
     }

--- a/src/app/views/querying/relational-algebra/relational-algebra.component.ts
+++ b/src/app/views/querying/relational-algebra/relational-algebra.component.ts
@@ -390,7 +390,7 @@ export class RelationalAlgebraComponent implements OnInit, AfterViewInit, OnDest
         const tree = this.getTree();
         if (tree === undefined) {
             $('#run i').removeClass().addClass('fa fa-play');
-            this._toast.toast('no plan', 'Please provide a plan to be executed.', 10, 'bg-warning');
+          this._toast.warn('Please provide a plan to be executed.', 'no plan');
             return;
         }
         this._crud.executeRelAlg(tree).subscribe(
@@ -398,8 +398,8 @@ export class RelationalAlgebraComponent implements OnInit, AfterViewInit, OnDest
                 $('#run i').removeClass().addClass('fa fa-play');
                 this.resultSet = <ResultSet>res;
             }, err => {
-                $('#run i').removeClass().addClass('fa fa-play');
-                this._toast.toast('Server error', 'Could not execute relational algebra: ', 0, 'bg-danger');
+            $('#run i').removeClass().addClass('fa fa-play');
+            this._toast.error('Could not execute relational algebra');
             }
         );
     }
@@ -430,8 +430,8 @@ export class RelationalAlgebraComponent implements OnInit, AfterViewInit, OnDest
                 //get only node in Map
                 tree = this.walkTree(this.nodes.values().next().value.clone());
             } else {
-                //$('#run i').removeClass().addClass('fa fa-play');
-                //this._toast.toast( 'no plan', 'Please provide a plan to be executed.', 10, 'bg-warning' );
+              //$('#run i').removeClass().addClass('fa fa-play');
+              //this._toast.warn( 'Please provide a plan to be executed.', 'no plan' );
                 return undefined;
             }
         } else {
@@ -506,8 +506,8 @@ export class RelationalAlgebraComponent implements OnInit, AfterViewInit, OnDest
         }
         // see https://2ality.com/2015/08/es6-map-json.html
         const out = {nodes: [...this.nodes], connections: [...this.connections]};
-        this.copyMessage(JSON.stringify(out));
-        this._toast.toast('exported', 'The plan was exported to JSON and copied to your clipboard', 5, 'bg-success');
+      this.copyMessage(JSON.stringify(out));
+      this._toast.success('The plan was exported to JSON and copied to your clipboard', 'exported');
     }
 
     /**

--- a/src/app/views/schema-editing/edit-columns/edit-columns.component.ts
+++ b/src/app/views/schema-editing/edit-columns/edit-columns.component.ts
@@ -1,11 +1,10 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, Input, OnInit} from '@angular/core';
 import {ActivatedRoute} from '@angular/router';
 import * as $ from 'jquery';
 import {LeftSidebarService} from '../../../components/left-sidebar/left-sidebar.service';
 import {CrudService} from '../../../services/crud.service';
 import {DbColumn, Index, ResultSet, TableConstraint} from '../../../components/data-table/models/result-set.model';
-import {ToastService} from '../../../components/toast/toast.service';
-import {Input} from '@angular/core';
+import {ToastDuration, ToastService} from '../../../components/toast/toast.service';
 import {FormControl, FormGroup, Validators} from '@angular/forms';
 import {ColumnRequest, ConstraintRequest, EditTableRequest} from '../../../models/ui-request.model';
 import {DbmsTypesService} from '../../../services/dbms-types.service';
@@ -102,7 +101,7 @@ export class EditColumnsComponent implements OnInit {
         // deep copy: from: https://stackoverflow.com/questions/35504310/deep-copy-an-array-in-angular-2-typescript
         this.newPrimaryKey = this.resultSet.header.map( x => Object.assign({}, x));
       }, err => {
-        this._toast.toast( 'server error', 'Could not load columns of the table.', 0, 'bg-danger' );
+        this._toast.error('Could not load columns of the table.', null, ToastDuration.INFINITE);
         console.log(err);
       }
     );
@@ -127,7 +126,7 @@ export class EditColumnsComponent implements OnInit {
 
   saveCol() {
     if( ! this._crud.nameIsValid( this.updateColumn.controls['name'].value ) ){
-      this._toast.toast( 'invalid column name', this._crud.invalidNameMessage('column'), 10, 'bg-warning' );
+      this._toast.warn(this._crud.invalidNameMessage('column'), 'invalid column name');
       return;
     }
     const oldColumn = this.oldColumns.get( this.updateColumn.controls['oldName'].value );
@@ -148,12 +147,12 @@ export class EditColumnsComponent implements OnInit {
         this.editColumn = -1;
         this.getColumns();
         if( result.error ){
-          this._toast.toast( 'error', 'Could not update column: '+result.error, 0, 'bg-warning' );
+          this._toast.warn('Could not update column: ' + result.error);
         }else{
-          this._toast.toast( 'column saved', 'The new column was saved.', 10, 'bg-success' );
+          this._toast.success('The new column was saved.', 'column saved');
         }
       }, err => {
-        this._toast.toast( 'server error', 'Could not save column due to an error on the server.', 0, 'bg-danger' );
+        this._toast.error('Could not save column due to an error on the server.', null, ToastDuration.INFINITE);
         console.log(err);
       }
     );
@@ -161,11 +160,11 @@ export class EditColumnsComponent implements OnInit {
 
   addColumn() {
     if( this.createColumn.name === ''){
-      this._toast.toast( 'missing column name', 'Please provide a name for the new column.', 0, 'bg-warning');
+      this._toast.warn('Please provide a name for the new column.', 'missing column name');
       return;
     }
     if( ! this._crud.nameIsValid( this.createColumn.name ) ){
-      this._toast.toast( 'invalid column name', this._crud.invalidNameMessage('column'), 10, 'bg-warning' );
+      this._toast.warn(this._crud.invalidNameMessage('column'), 'invalid column name');
       return;
     }
     if( ! ['varchar', 'varbinary'].includes(this.createColumn.dataType.toLowerCase()) && this.createColumn.maxLength !== null ){
@@ -184,10 +183,10 @@ export class EditColumnsComponent implements OnInit {
           this.createColumn.maxLength = null;
           this.createColumn.defaultValue = null;
         } else {
-          this._toast.toast( 'server error', result.error, 0, 'bg-warning' );
+          this._toast.warn(result.error, 'server error', ToastDuration.INFINITE);
         }
       }, err => {
-        this._toast.toast( 'server error', 'An error occured on the server.', 0, 'bg-danger' );
+        this._toast.error('An error occurred on the server.', null, ToastDuration.INFINITE);
         console.log(err);
     }
     );
@@ -203,10 +202,10 @@ export class EditColumnsComponent implements OnInit {
           this.confirm = -1;
           const result = <ResultSet> res;
           if( result.error ){
-            this._toast.toast( 'server error', 'Could not delete column:\n' + result.error, 0, 'bg-warning' );
+            this._toast.warn('Could not delete column:\n' + result.error, 'server error', ToastDuration.INFINITE);
           }
         }, err => {
-          this._toast.toast( 'server error', 'Could not delete column.', 0, 'bg-danger' );
+          this._toast.error('Could not delete column.', null, ToastDuration.INFINITE);
           console.log(err);
         }
       );
@@ -231,7 +230,7 @@ export class EditColumnsComponent implements OnInit {
         res => {
           const result = <ResultSet> res;
           if( result.error){
-            this._toast.toast( 'constraint error', result.error, 10, 'bg-warning');
+            this._toast.warn(result.error, 'constraint error');
           }else{
             this.getConstraints();
           }
@@ -255,13 +254,13 @@ export class EditColumnsComponent implements OnInit {
         const result = <ResultSet> res;
         if( !result.error ){
           this.getConstraints();
-          this._toast.toast( 'added primary key', 'The primary key was added.', 5, 'bg-success' );
+          this._toast.success('The primary key was added.', 'added primary key');
           this.getColumns();
         }else {
-          this._toast.toast( 'primary key error', result.error, 0, 'bg-warning');
+          this._toast.warn(result.error, 'primary key error', ToastDuration.INFINITE);
         }
       }, err => {
-        this._toast.toast( 'Server error', 'Could not add primary key.', 0, 'bg-danger');
+        this._toast.error('Could not add primary key.', null, ToastDuration.INFINITE);
         console.log(err);
       }
     );
@@ -269,11 +268,11 @@ export class EditColumnsComponent implements OnInit {
 
   addUniqueConstraint(){
     if( this.uniqueConstraintName === '' ){
-      this._toast.toast( 'constraint name', 'Please provide a name for the unique constraint.', 10, 'bg-warning' );
+      this._toast.warn('Please provide a name for the unique constraint.', 'constraint name');
       return;
     }
     if( ! this._crud.nameIsValid( this.uniqueConstraintName ) ){
-      this._toast.toast( 'invalid constraint name', this._crud.invalidNameMessage('unique constraint'), 10, 'bg-warning' );
+      this._toast.warn(this._crud.invalidNameMessage('unique constraint'), 'invalid constraint name');
       return;
     }
     const constraint = new TableConstraint( this.uniqueConstraintName, 'UNIQUE');
@@ -285,7 +284,7 @@ export class EditColumnsComponent implements OnInit {
       }
     });
     if( counter === 0 ) {
-      this._toast.toast( 'unique constraint', 'Please select at least one column that should be part of the unique constraint.', 10, 'bg-warning' );
+      this._toast.warn('Please select at least one column that should be part of the unique constraint.', 'unique constraint');
       return;
     }
     const constraintRequest = new ConstraintRequest( this.tableId, constraint );
@@ -294,16 +293,16 @@ export class EditColumnsComponent implements OnInit {
         const result = <ResultSet> res;
         if( !result.error ){
           this.getConstraints();
-          this._toast.toast( 'added constraint', 'The unique constraint was successfully created', 5, 'bg-success' );
+          this._toast.success('The unique constraint was successfully created', 'added constraint');
           this.uniqueConstraintName = '';
           this.resultSet.header.forEach((v, k) => {
             v.unique = false;
           });
         }else {
-          this._toast.toast( 'unique constraint error', result.error, 0, 'bg-warning');
+          this._toast.warn(result.error, 'unique constraint error', ToastDuration.INFINITE);
         }
       }, err => {
-        this._toast.toast( 'Server error', 'Could not add unique constraint.', 0, 'bg-danger');
+        this._toast.error('Could not add unique constraint.', null, ToastDuration.INFINITE);
         console.log(err);
       }
     );
@@ -406,7 +405,7 @@ export class EditColumnsComponent implements OnInit {
           if( !result.error ){
             this.getIndexes();
           }else{
-            this._toast.toast( 'error', 'Could not drop index: ' + result.error, 10, 'bg-warning');
+            this._toast.warn('Could not drop index: ' + result.error);
           }
         }, err => {
           console.log(err);
@@ -426,7 +425,7 @@ export class EditColumnsComponent implements OnInit {
           if( !result.error ){
             this.getIndexes();
           }else{
-            this._toast.toast( 'error', 'Could not create index: ' + result.error, 10, 'bg-warning');
+            this._toast.warn('Could not create index: ' + result.error);
           }
         }, err => {
           console.log(err);

--- a/src/app/views/schema-editing/edit-tables/edit-tables.component.ts
+++ b/src/app/views/schema-editing/edit-tables/edit-tables.component.ts
@@ -3,7 +3,7 @@ import {CrudService} from '../../../services/crud.service';
 import {EditTableRequest, SchemaRequest} from '../../../models/ui-request.model';
 import {ActivatedRoute} from '@angular/router';
 import {DbColumn, ResultSet, Status} from '../../../components/data-table/models/result-set.model';
-import {ToastService} from '../../../components/toast/toast.service';
+import {ToastDuration, ToastService} from '../../../components/toast/toast.service';
 import {LeftSidebarService} from '../../../components/left-sidebar/left-sidebar.service';
 import {DbmsTypesService} from '../../../services/dbms-types.service';
 import {FormControl, FormGroup, Validators} from '@angular/forms';
@@ -67,7 +67,7 @@ export class EditTablesComponent implements OnInit, OnDestroy {
       res => {
         const result = <ResultSet> res;
         if( result.error !== undefined ){
-          this._toast.toast( 'error', 'Could not retrieve list of tables: '+result.error, 10, 'bg-warning' );
+          this._toast.warn('Could not retrieve list of tables: ' + result.error);
         }
         this.tables = result.tables;
         this.tables.forEach((val, key) => {
@@ -75,7 +75,7 @@ export class EditTablesComponent implements OnInit, OnDestroy {
           this.drop[key] = '';
         });
       }, err => {
-        this._toast.toast( 'server error', 'could not retrieve list of tables', 10, 'bg-danger' );
+        this._toast.error('could not retrieve list of tables');
         console.log(err);
       }
     );
@@ -97,34 +97,34 @@ export class EditTablesComponent implements OnInit, OnDestroy {
       res => {
         const result = <ResultSet> res;
         if( result.error ){
-          this._toast.toast( 'error', 'Could not '+action+' the table '+table+': '+result.error, 10, 'bg-warning' );
+          this._toast.warn('Could not ' + action + ' the table ' + table + ': ' + result.error);
         }else {
           let toastAction = 'Truncated';
           if( request.getAction() === 'drop'){
             toastAction = 'Dropped';
             this._leftSidebar.setSchema( new SchemaRequest('/views/schema-editing/', false, 2) );
           }
-          this._toast.toast('success', toastAction + ' table '+request.table, 10, 'bg-success');
+          this._toast.success(toastAction + ' table ' + request.table);
           this.getTables();
         }
       }, err => {
-        this._toast.toast( 'server error', 'Could not '+action+' the table '+table+' due to an unknown error', 10, 'bg-danger' );
-        console.log( err );
+        this._toast.error('Could not ' + action + ' the table ' + table + ' due to an unknown error');
+        console.log(err);
       }
     );
   }
 
   createTable () {
     if(this.newTableName === ''){
-      this._toast.toast( 'missing table name', 'Please provide a name for the new table. The new table was not created.', 0, 'bg-warning');
+      this._toast.warn('Please provide a name for the new table. The new table was not created.', 'missing table name', ToastDuration.INFINITE);
       return;
     }
     if( !this._crud.nameIsValid(this.newTableName) ){
-      this._toast.toast( 'invalid table name', 'Please provide a valid name for the new table. The new table was not created.', 0, 'bg-warning');
+      this._toast.warn('Please provide a valid name for the new table. The new table was not created.', 'invalid table name', ToastDuration.INFINITE);
       return;
     }
     if( this.tables.indexOf( this.newTableName ) !== -1 ){
-      this._toast.toast( 'invalid table name', 'A table with this name already exists. Please choose another name.', 0, 'bg-warning');
+      this._toast.warn('A table with this name already exists. Please choose another name.', 'invalid table name', ToastDuration.INFINITE);
       return;
     }
     let valid = true;
@@ -143,7 +143,7 @@ export class EditTablesComponent implements OnInit, OnDestroy {
       }
     });
     if ( !valid ){
-      this._toast.toast( 'invalid column name', 'Please make sure all column names are valid. The new table was not created.', 0, 'bg-warning');
+      this._toast.warn('Please make sure all column names are valid. The new table was not created.', 'invalid column name', ToastDuration.INFINITE);
       return;
     }
     const request = new EditTableRequest( this.schema, this.newTableName, 'create', Array.from(this.newColumns.values()) );
@@ -151,9 +151,9 @@ export class EditTablesComponent implements OnInit, OnDestroy {
       res => {
         const result = <ResultSet> res;
         if( result.error ) {
-          this._toast.toast( 'error', 'Could not generate table: '+result.error, 10, 'bg-warning' );
+          this._toast.warn('Could not generate table: ' + result.error);
         } else {
-          this._toast.toast('success', 'Generated table ' + request.table, 5, 'bg-success' );
+          this._toast.success('Generated table ' + request.table);
           this.newColumns.clear();
           this.counter = 0;
           this.newColumns.set( this.counter++, new DbColumn('', false, false, this.types[0], null));
@@ -162,8 +162,8 @@ export class EditTablesComponent implements OnInit, OnDestroy {
         }
         this.getTables();
       }, err => {
-        this._toast.toast( 'server error', 'Could not generate table', 10, 'bg-warning' );
-        console.log( err );
+        this._toast.error('Could not generate table');
+        console.log(err);
       }
     );
   }
@@ -203,12 +203,12 @@ export class EditTablesComponent implements OnInit, OnDestroy {
         res => {
           const result = <ResultSet> res;
           if( result.error ){
-            this._toast.toast( 'error', result.error, 5, 'bg-warning');
+            this._toast.warn(result.error);
           } else {
-            this._toast.toast( 'success', 'Exported table to Polypheny-Hub', 5, 'bg-success');
+            this._toast.success('Exported table to Polypheny-Hub');
           }
         }, err => {
-          this._toast.toast( 'error', 'Could not export table', 5, 'bg-danger');
+          this._toast.error('Could not export table');
           console.log(err);
         }
         //"finally block"

--- a/src/app/views/schema-editing/schema-editing.component.ts
+++ b/src/app/views/schema-editing/schema-editing.component.ts
@@ -93,19 +93,19 @@ export class SchemaEditingComponent implements OnInit, OnDestroy {
         res => {
           const result = <ResultSet> res;
           if( result.error ){
-            this._toast.toast( 'error', result.error, 10, 'bg-warning');
+            this._toast.warn(result.error);
           }else{
-            this._toast.toast( 'success', 'Created schema ' + val.name, 10, 'bg-success');
+            this._toast.success('Created schema ' + val.name);
             this.getSchema();
           }
           this.createSubmitted = false;
           this.resetForm('createForm');
         }, err => {
-          this._toast.toast( 'server error', 'An unknown error occured on the server', 10, 'bg-danger');
+          this._toast.error('An unknown error occurred on the server');
         }
       );
     } else {
-      this._toast.toast( 'cannot create', this.createSchemaFeedback, 10, 'bg-warning');
+      this._toast.warn(this.createSchemaFeedback, 'cannot create');
     }
   }
 
@@ -117,19 +117,19 @@ export class SchemaEditingComponent implements OnInit, OnDestroy {
         res => {
           const result = <ResultSet> res;
           if( result.error ){
-            this._toast.toast( 'error', result.error, 10, 'bg-warning');
+            this._toast.warn(result.error);
           }else{
-            this._toast.toast( 'success', 'Dropped schema ' + val.name, 10, 'bg-success');
+            this._toast.success('Dropped schema ' + val.name);
             this.getSchema();
           }
           this.dropSubmitted = false;
           this.resetForm('dropForm');
         }, err => {
-          this._toast.toast( 'server error', 'An unknown error occured on the server', 10, 'bg-danger');
+          this._toast.error('An unknown error occurred on the server');
         }
       );
     } else {
-      this._toast.toast( 'cannot drop', 'This schema does not exist', 10, 'bg-warning');
+      this._toast.warn('This schema does not exist', 'cannot drop');
     }
 
   }

--- a/src/app/views/stores/stores.component.ts
+++ b/src/app/views/stores/stores.component.ts
@@ -115,11 +115,11 @@ export class StoresComponent implements OnInit, OnDestroy {
     }
     this._crud.updateStoreSettings( store ).subscribe(
       res => {
-        this._toast.toast( 'success', 'updated store settings', 5, 'bg-success');
+        this._toast.success('updated store settings');
         this.storeSettingsModal.hide();
         this.getStores();
       }, err => {
-        this._toast.toast( 'error', 'could not update store settings', 5, 'bg-danger');
+        this._toast.error('could not update store settings');
         console.log(err);
       }
     );
@@ -174,14 +174,14 @@ export class StoresComponent implements OnInit, OnDestroy {
     this._crud.addStore( deploy ).subscribe(
       res => {
         if(<boolean> res === true){
-          this._toast.toast( 'success', 'Deployed store', 5, 'bg-success');
+          this._toast.success('Deployed store');
           this._router.navigate(['./../'], {relativeTo: this._route});
         } else {
-          this._toast.toast( 'error', 'Could not deploy store', 5, 'bg-warning');
+          this._toast.warn('Could not deploy store');
         }
         this.storeSettingsModal.hide();
       }, err => {
-        this._toast.toast( 'error', 'Could not deploy store', 5, 'bg-danger');
+        this._toast.error('Could not deploy store');
       }
     );
   }
@@ -194,13 +194,13 @@ export class StoresComponent implements OnInit, OnDestroy {
         res => {
           const result = <boolean> res;
           if(result){
-            this._toast.toast( 'success', 'Removed store', 5, 'bg-success');
+            this._toast.success('Removed store');
             this.getStores();
           }else{
-            this._toast.toast( 'error', 'Could not remove store', 5, 'bg-warning');
+            this._toast.warn('Could not remove store');
           }
         }, err => {
-          this._toast.toast( 'error', 'Could not remove store', 5, 'bg-danger');
+          this._toast.error('Could not remove store', 'server error');
           console.log(err);
         }
       );

--- a/src/app/views/uml/uml.component.ts
+++ b/src/app/views/uml/uml.component.ts
@@ -7,7 +7,7 @@ import {DbTable, ForeignKey, SvgLine, Uml} from './uml.model';
 import {LeftSidebarService} from '../../components/left-sidebar/left-sidebar.service';
 import {ModalDirective} from 'ngx-bootstrap';
 import {FormBuilder} from '@angular/forms';
-import {ToastService} from '../../components/toast/toast.service';
+import {ToastDuration, ToastService} from '../../components/toast/toast.service';
 import {DbColumn, ResultSet} from '../../components/data-table/models/result-set.model';
 import {DbmsTypesService} from '../../services/dbms-types.service';
 
@@ -205,7 +205,7 @@ export class UmlComponent implements OnInit, AfterViewInit, OnDestroy {
 
   createForeignKey(){
     if( ! this._crud.nameIsValid( this.constraintName )){
-      this._toast.toast( 'invalid constraint name', this._crud.invalidNameMessage('constraint'), 0, 'bg-warning');
+      this._toast.warn(this._crud.invalidNameMessage('constraint'), 'invalid constraint name', ToastDuration.INFINITE);
       return;
     }
     const fk: ForeignKey = new ForeignKey( this.constraintName, this.schema, this.sourceTable, this.sourceCol, this.targetTable, this.targetCol )
@@ -216,10 +216,10 @@ export class UmlComponent implements OnInit, AfterViewInit, OnDestroy {
         this.closeModal();
         const result = <ResultSet> res;
         if( result.error ){
-          this._toast.toast( 'failed', result.error, 0, 'bg-warning');
+          this._toast.warn(result.error, null, ToastDuration.INFINITE);
         }
         else if( result.info.affectedRows === 1) {
-          this._toast.toast( 'success', 'new foreign key was created', 10, 'bg-success');
+          this._toast.success('new foreign key was created');
           // this.getUml();
           // this.connectTables();
           const fkTable = fk.fkTableName.substr(fk.fkTableName.indexOf('.')+1, fk.fkTableName.length);
@@ -228,7 +228,7 @@ export class UmlComponent implements OnInit, AfterViewInit, OnDestroy {
         }
       }, err => {
         this.closeModal();
-        this._toast.toast( 'error', 'An unknown error occurred on the server', 10, 'bg-danger');
+        this._toast.error('An unknown error occurred on the server');
       }
     );
   }


### PR DESCRIPTION
The refactoring of the toast service tries to achieve two goals: To make it easier to generate toast messages and to achieve more consistency in the UI.
The toast function was replaced with three functions:

success(message: string, title = 'success', duration: ToastDuration = ToastDuration.NORMAL)
warn(message: string, title = 'warning', duration: ToastDuration = ToastDuration.LONG)
error(message: string, title = 'error', duration: ToastDuration = ToastDuration.LONG)

It is sufficient to call a function with only the message text. Optionally another title can be provided.
If desired, the duration can be changed using the ToastDuration enum. Please use this functionality only if you want a message to appear only very shortly (ToastDuration.SHORT) or if you don't want the message to disappear after a timeout (ToastDuration.INFINITE). Use specific durations only sparingly, so that more consistency can be achieved in the UI.