### PR TITLE
LocalStorage Quota Google Chrome Issue #369

### DIFF
--- a/src/app/explain-visualizer/components/plan-view/plan-view.component.ts
+++ b/src/app/explain-visualizer/components/plan-view/plan-view.component.ts
@@ -2,14 +2,13 @@ import {Component, Input, OnInit, ViewEncapsulation} from '@angular/core';
 import {IPlan} from '../../models/iplan';
 import {HighlightType, ViewMode} from '../../models/enums';
 import {PlanService} from '../../services/plan.service';
-import { OnDestroy } from '@angular/core';
 
 @Component({
   selector: 'app-plan-view',
   templateUrl: './plan-view.component.html',
   styleUrls: ['./plan-view.component.scss'],
 })
-export class PlanViewComponent implements OnInit, OnDestroy {
+export class PlanViewComponent implements OnInit {
 
   id: string;
   plan: IPlan;
@@ -60,10 +59,6 @@ export class PlanViewComponent implements OnInit, OnDestroy {
 
   analyzePlan() {
     this._planService.analyzePlan(this.plan);
-  }
-
-  ngOnDestroy(): void {
-    this._planService.deletePlan(this.plan);
   }
 
 }

--- a/src/app/explain-visualizer/components/plan-view/plan-view.component.ts
+++ b/src/app/explain-visualizer/components/plan-view/plan-view.component.ts
@@ -2,13 +2,14 @@ import {Component, Input, OnInit, ViewEncapsulation} from '@angular/core';
 import {IPlan} from '../../models/iplan';
 import {HighlightType, ViewMode} from '../../models/enums';
 import {PlanService} from '../../services/plan.service';
+import { OnDestroy } from '@angular/core';
 
 @Component({
   selector: 'app-plan-view',
   templateUrl: './plan-view.component.html',
   styleUrls: ['./plan-view.component.scss'],
 })
-export class PlanViewComponent implements OnInit {
+export class PlanViewComponent implements OnInit, OnDestroy {
 
   id: string;
   plan: IPlan;
@@ -59,6 +60,10 @@ export class PlanViewComponent implements OnInit {
 
   analyzePlan() {
     this._planService.analyzePlan(this.plan);
+  }
+
+  ngOnDestroy(): void {
+    this._planService.deletePlan(this.plan);
   }
 
 }

--- a/src/app/explain-visualizer/services/plan.service.ts
+++ b/src/app/explain-visualizer/services/plan.service.ts
@@ -115,7 +115,6 @@ export class PlanService {
 
     this.findOutlierNodes(plan.content.Plan);
 
-    localStorage.setItem(plan.id, JSON.stringify(plan));
   }
 
   deletePlan(plan: IPlan) {


### PR DESCRIPTION
This PR removes the overuse of the localStorage when query plans are opened and cached.
For this the plan gets deleted when the component is destroyed.

This fixes [#369](https://github.com/polypheny/Polypheny-DB/issues/369).