### PR TITLE
Conditionaly remove Explore-By-Example

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/app/containers/default-layout/default-layout.component.html
+++ b/src/app/containers/default-layout/default-layout.component.html
@@ -59,7 +59,7 @@
           <a class="dropdown-item" [routerLink]="['/views/querying/relational-algebra']" routerLinkActive="active">
             <i class="fa fa-cubes"></i><span class="d-md-down-none">Plan Builder</span>
           </a>
-          <a class="dropdown-item" [routerLink]="['/views/querying/explore-by-example']" routerLinkActive="active">
+          <a *ngIf="exploreByExampleEnabled()" class="dropdown-item" [routerLink]="['/views/querying/explore-by-example']" routerLinkActive="active">
             <i class="fa fa-magic"></i><span class="d-md-down-none">Explore by Example</span>
           </a>
         </div>

--- a/src/app/containers/default-layout/default-layout.component.ts
+++ b/src/app/containers/default-layout/default-layout.component.ts
@@ -14,6 +14,7 @@ export class DefaultLayoutComponent implements OnDestroy {
   public sidebarMinimized = true;
   private changes: MutationObserver;
   public element: HTMLElement;
+  private enabledPlugins: string[] = undefined;
   constructor(
     public _sidebar: LeftSidebarService,
     public _information: InformationService,
@@ -36,5 +37,10 @@ export class DefaultLayoutComponent implements OnDestroy {
 
   getConnectionClass () {
     return this._information.connected ? 'connected' : 'disconnected';
+  }
+
+  exploreByExampleEnabled() {
+    return this._information.getEnabledPlugins().includes('Explore-By-Example');
+
   }
 }

--- a/src/app/containers/default-layout/default-layout.component.ts
+++ b/src/app/containers/default-layout/default-layout.component.ts
@@ -14,7 +14,6 @@ export class DefaultLayoutComponent implements OnDestroy {
   public sidebarMinimized = true;
   private changes: MutationObserver;
   public element: HTMLElement;
-  private enabledPlugins: string[] = undefined;
   constructor(
     public _sidebar: LeftSidebarService,
     public _information: InformationService,

--- a/src/app/services/information.service.ts
+++ b/src/app/services/information.service.ts
@@ -5,9 +5,10 @@ import {WebuiSettingsService} from './webui-settings.service';
 import {InformationObject} from '../models/information-page.model';
 
 @Injectable({
-  providedIn: 'root'
+    providedIn: 'root'
 })
 export class InformationService {
+    private enabledPlugins: [string] = null;
 
   constructor( private _http:HttpClient, private _settings:WebuiSettingsService ) {
     this.initWebSocket();
@@ -39,33 +40,45 @@ export class InformationService {
     return this._http.post(`${this.httpUrl}/executeAction`, JSON.stringify(i), this.httpOptions);
   }
 
-  //websocket:
-  //https://rxjs-dev.firebaseapp.com/api/webSocket/webSocket
-  //openObserver:
-  //https://rxjs-dev.firebaseapp.com/api/webSocket/WebSocketSubjectConfig
-  //it's not possible to suppress the websocket exception during the reconnect:
-  //https://stackoverflow.com/questions/31978298/suppress-websocket-connection-to-xyz-failed
-  private initWebSocket() {
-    this.socket = webSocket({
-      url: this._settings.getConnection('information.socket'),
-      openObserver: {
-        next: (n) => {
-          this.reconnected.emit(true);
-          this.connected = true;
+    getEnabledPlugins(): string[] {
+        if( this.enabledPlugins == null ) {
+            this._http.get(`${this.httpUrl}/getEnabledPlugins`, this.httpOptions)
+                .subscribe(res => {
+                    this.enabledPlugins = <[string]>res;
+                });
+            return [];
         }
-      }
-    });
-    this.socket.subscribe(
-      msg => {},
-      err => {
-        //this.reconnected.emit(false);
-        this.connected = false;
-        setTimeout(() => {
-          this.initWebSocket();
-        }, +this._settings.getSetting('reconnection.timeout'));
-      }
-    );
-  }
+        return this.enabledPlugins;
+    }
+
+    //websocket:
+    //https://rxjs-dev.firebaseapp.com/api/webSocket/webSocket
+    //openObserver:
+    //https://rxjs-dev.firebaseapp.com/api/webSocket/WebSocketSubjectConfig
+    //it's not possible to suppress the websocket exception during the reconnect:
+    //https://stackoverflow.com/questions/31978298/suppress-websocket-connection-to-xyz-failed
+    private initWebSocket() {
+        this.socket = webSocket({
+            url: this._settings.getConnection('information.socket'),
+            openObserver: {
+                next: (n) => {
+                    this.reconnected.emit(true);
+                    this.connected = true;
+                }
+            }
+        });
+        this.socket.subscribe(
+            msg => {
+            },
+            err => {
+                //this.reconnected.emit(false);
+                this.connected = false;
+                setTimeout(() => {
+                    this.initWebSocket();
+                }, +this._settings.getSetting('reconnection.timeout'));
+            }
+        );
+    }
 
   socketSend(msg: string) {
     this.socket.next(msg);

--- a/src/app/views/hub/hub.component.html
+++ b/src/app/views/hub/hub.component.html
@@ -215,7 +215,7 @@
           </ng-container>
           <span *ngIf="!hubMeta">This dataset can be downloaded, but not imported.</span>
           <input type="hidden" [value]="downloadPath" formControlName="url">
-          <p class="text-danger mb-0" *ngIf="importDsFormSubmitted && !importDsForm.valid">Please select a schema and store before importing into Polypheny.</p>
+          <p class="text-danger mb-0" *ngIf="(importDsFormSubmitted || errorSubmitted) && !importDsForm.valid">Please select a schema and store before importing into Polypheny.</p>
         </div>
         <div class="modal-footer" style="justify-content: space-between">
           <div>

--- a/src/app/views/hub/hub.component.ts
+++ b/src/app/views/hub/hub.component.ts
@@ -58,6 +58,7 @@ export class HubComponent implements OnInit, OnDestroy {
     dataset: new FormControl( null, [Validators.required, Validators.pattern(/\.zip$/)] ) // , requiredFileType('zip')
   });
   newDsFormSubmitted = false;
+  errorSubmitted = false;
   fileToUpload;
   uploadProgress = 0;
 
@@ -497,6 +498,7 @@ export class HubComponent implements OnInit, OnDestroy {
     this.importDsFormSubmitted = true;
     this.importProgress = 0;
     if(this.importDsForm.valid){
+      this.errorSubmitted = false;
       //get import status: see initWebsocket()
       this._crud.importDataset(
         this.hubMeta.tables,
@@ -519,6 +521,10 @@ export class HubComponent implements OnInit, OnDestroy {
           console.log(err);
         }
       ).add(()=> this.importProgress = -1 );
+    }else {
+      this.importDsFormSubmitted = false;
+      this.importProgress = -1;
+      this.errorSubmitted = true;
     }
   }
 
@@ -537,7 +543,6 @@ export class HubComponent implements OnInit, OnDestroy {
       });
     this.subscriptions.add(sub);
   }
-
 }
 enum LoginStatus {
   LOGGED_OUT = 0,

--- a/src/app/views/querying/explore-by-example/explore-by-example.component.html
+++ b/src/app/views/querying/explore-by-example/explore-by-example.component.html
@@ -1,22 +1,29 @@
 <div class="row" style="position: relative;">
     <app-toast></app-toast>
-    <div class="col-lg-12" >
-        <h4>Explore by Example</h4>
-        <p class="d-inline-block">Select columns from the left sidebar to get started.  As soon as all needed columns have been selected, the process can be started with Start Process.</p>
+    <ng-container *ngIf="exploreByExampleEnabled()">
+        <div class="col-lg-12" >
+            <h4>Explore by Example</h4>
+            <p class="d-inline-block">Select columns from the left sidebar to get started.  As soon as all needed columns have been selected, the process can be started with Start Process.</p>
 
-        <div class="float-right d-flex">
-            <p class="d-inline-block">  Tutorial Mode  </p>
-            <label class="switch switch-pill switch-primary" id="switch-tutorial">
-                <input type="checkbox" class="switch-input" [(ngModel)]="this.tutorialMode">
-                <span class="switch-slider" ></span>
-            </label>
+            <div class="float-right d-flex">
+                <p class="d-inline-block">  Tutorial Mode  </p>
+                <label class="switch switch-pill switch-primary" id="switch-tutorial">
+                    <input type="checkbox" class="switch-input" [(ngModel)]="this.tutorialMode">
+                    <span class="switch-slider" ></span>
+                </label>
+            </div>
         </div>
-    </div>
-    <div class="col-lg-12">
-        <button type="button" id="explore-button" class="btn btn-primary" (click)="selectedColumns()">Start Process</button>
-        <!--<button id="infoExploreProcess" type="button" class="btn btn-primary float-right"  (click)="openModal(informationExploreProcess)">Information Explore Process</button>-->
-    </div>
-
+        <div class="col-lg-12">
+            <button type="button" id="explore-button" class="btn btn-primary" (click)="selectedColumns()">Start Process</button>
+            <!--<button id="infoExploreProcess" type="button" class="btn btn-primary float-right"  (click)="openModal(informationExploreProcess)">Information Explore Process</button>-->
+        </div>
+    </ng-container>
+    <ng-container *ngIf="!exploreByExampleEnabled()">
+        <div class="col-lg-12" >
+            <p>This version of Polypheny does not come bundled with Explore-By-Example due to licencing. To enable Explore-By-Example, Polypheny can be built yourself following this guide:</p>
+            <a href="https://polypheny.org/documentation/Setup/">Polypheny Documentation</a>
+        </div>
+    </ng-container>
 </div>
 
 

--- a/src/app/views/querying/explore-by-example/explore-by-example.component.ts
+++ b/src/app/views/querying/explore-by-example/explore-by-example.component.ts
@@ -13,6 +13,7 @@ import {Subscription} from 'rxjs';
 import {TableConfig} from '../../../components/data-view/data-table/table-config';
 import {WebSocket} from '../../../services/webSocket';
 import {WebuiSettingsService} from '../../../services/webui-settings.service';
+import {InformationService} from '../../../services/information.service';
 
 @Component({
   selector: 'app-explore-by-example',
@@ -70,6 +71,7 @@ export class ExploreByExampleComponent implements OnInit, OnDestroy {
     private _leftSidebar: LeftSidebarService,
     private _toast: ToastService,
     private _settings: WebuiSettingsService,
+    private _information: InformationService,
     private modalService: BsModalService) {
     this.websocket = new WebSocket(_settings);
   }
@@ -275,6 +277,9 @@ export class ExploreByExampleComponent implements OnInit, OnDestroy {
     );
   }
 
+  exploreByExampleEnabled(): boolean {
+      return this._information.getEnabledPlugins().includes('Explore-By-Example');
+  }
 }
 
 class JoinCondition {


### PR DESCRIPTION
This PR toggles the visibility of all Explore-By-Example functionality depending on the EnabledPlugins route from Polypheny-DB.
If the site is opened manually the page displays a explanation and links to the setup page of [polypheny.org](https://polypheny.org).

Minor Bug-Fix
- Polypheny-Hub import validation fixed