### PR TITLE
Styling the plain search box in the sidebar similar to the wrapped search box

### DIFF
--- a/src/app/components/left-sidebar/left-sidebar.component.html
+++ b/src/app/components/left-sidebar/left-sidebar.component.html
@@ -6,7 +6,7 @@
       <a [routerLink]="[]" (click)="collapseAll()" id="collapse"><i class="fa fa-compress"></i></a>
       </span>
     </div>
-    <input type="text" class="form-control form-control-sm" placeholder="search" id="search-tree">
+    <input type="text" class="form-control form-control-sm" [class]="{'rounded-search': !isExpandAndCollapseShown()}" placeholder="search" id="search-tree">
     <div class="input-group-append">
     <span *ngIf="isExpandAndCollapseShown()" class="input-group-text">
         <a [routerLink]="[]" (click)="expandAll()" id="expand"><i class="fa fa-expand"></i></a>

--- a/src/app/components/left-sidebar/left-sidebar.component.scss
+++ b/src/app/components/left-sidebar/left-sidebar.component.scss
@@ -98,3 +98,8 @@
 .node-disabled {
   display: none;
 }
+
+
+.rounded-search {
+  border-radius: 0.2rem !important;
+}


### PR DESCRIPTION
Adds a conditional styling to the search box in the sidebar if no expanders are shown for the specific pages.
This keeps the look of Polypheny more uniform with the general used styling.

From:
![image](https://user-images.githubusercontent.com/5930207/193585055-63267ee6-48ce-4c85-90c8-f7a56852155e.png)

To:
![image](https://user-images.githubusercontent.com/5930207/193584747-be9760b0-29c1-4fb3-a4bb-77fd1875676b.png)
