### PR TITLE
Hotfix: Empty Namespace in Advanced Console

### DIFF
--- a/src/app/views/query-interfaces/query-interfaces.component.ts
+++ b/src/app/views/query-interfaces/query-interfaces.component.ts
@@ -184,14 +184,14 @@ export class QueryInterfacesComponent implements OnInit, OnDestroy {
       res => {
         const result = <ResultSet> res;
         if( !result.error ){
-          this._toast.success('Added query interface', result.generatedQuery);
+          this._toast.success('Added query interface: ' + deploy.uniqueName, result.generatedQuery);
           this._router.navigate(['./../'], {relativeTo: this._route});
         } else {
           this._toast.exception( result );
         }
         this.QISettingsModal.hide();
       }, err => {
-        this._toast.error('Could not add query interface');
+        this._toast.error('Could not add query interface: ' + deploy.uniqueName );
         console.log(err);
       }
     );
@@ -205,13 +205,13 @@ export class QueryInterfacesComponent implements OnInit, OnDestroy {
         res => {
           const result = <ResultSet> res;
           if(!result.error){
-            this._toast.success('Removed queryInterface', result.generatedQuery);
+            this._toast.success('Removed query interface: ' + queryInterface.uniqueName, result.generatedQuery);
             this.getQueryInterfaces();
           }else{
             this._toast.exception( result );
           }
         }, err => {
-          this._toast.error('Could not remove queryInterface', 'server error');
+          this._toast.error('Could not remove query interface: ' + queryInterface.uniqueName, 'server error');
           console.log(err);
         }
       );

--- a/src/app/views/querying/console/console.component.ts
+++ b/src/app/views/querying/console/console.component.ts
@@ -389,6 +389,10 @@ export class ConsoleComponent implements OnInit, OnDestroy {
 
     private setDefaultDB(name: string) {
         name = name.trim();
+        if( !this.namespaces.includes(name) ){
+            this.namespaces.push(name);
+        }
+
         this.activeNamespace = name;
         localStorage.setItem(this.LOCAL_STORAGE_NAMESPACE_KEY, name);
     }


### PR DESCRIPTION
This hotfix correctly adds newly created namespaces to the advanced console as drop-down option.
before:
![image](https://user-images.githubusercontent.com/5930207/198603202-89dbef46-20a3-4ae0-af69-7fcdee1e493a.png)
now:
![image](https://user-images.githubusercontent.com/5930207/198603418-3f0dc32b-d728-4d37-a824-acf8d53d1a13.png)

